### PR TITLE
Add job to publish image on successful PR from dependabot

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -80,6 +80,7 @@ jobs:
               --implementation "localhost/${IMAGE_WITH_TAG}" \
               --format json | jq -r '.version // empty')
           echo "value=${version}" >> $GITHUB_OUTPUT
+          echo "Collected version: $version"
 
       - name: Log in to ghcr.io
         uses: redhat-actions/podman-login@v1

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,114 @@
+name: Build test harness image
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        type: string
+        required: true
+        description: 'Name for the image to build'
+      publish-image:
+        type: boolean
+        default: false
+        description: 'Enables built image publication'
+      is-latest:
+        type: boolean
+        default: false
+        description: 'If image is the latest a corresponding tag is added to the image'
+    outputs:
+      current-version:
+        description: 'Version of the implementation from the built image'
+        value: ${{ jobs.build.outputs.current-version }}
+
+permissions: {}
+
+env:
+  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    outputs:
+      current-version: ${{ steps.current-version.outputs.value }}
+
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install bowtie
+        uses: bowtie-json-schema/bowtie@main
+
+      - name: Build
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          context: '.'
+          containerfiles: |
+            Dockerfile
+          image: ${{ inputs.image-name }}
+          tags: ${{ github.sha }} ${{ inputs.is-latest && 'latest' || '' }}
+          archs: amd64, arm64
+
+      - name: Set DOCKER_HOST so podman-built images are findable
+        run: |
+          systemctl --user enable --now podman.socket
+          sudo loginctl enable-linger $USER
+          podman --remote info
+          echo "DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')" >> $GITHUB_ENV
+
+      - name: Smoke Test
+        env:
+          IMAGE_WITH_TAG: ${{ steps.build_image.outputs.image-with-tag }}
+        run: |
+          bowtie smoke -i "localhost/${IMAGE_WITH_TAG}" --format json
+          bowtie smoke -i "localhost/${IMAGE_WITH_TAG}" --format markdown >> $GITHUB_STEP_SUMMARY
+
+      - name: Collect current version
+        id: current-version
+        env:
+          IMAGE_WITH_TAG: ${{ steps.build_image.outputs.image-with-tag }}
+        run: |
+          version=$(bowtie info \
+              --implementation "localhost/${IMAGE_WITH_TAG}" \
+              --format json | jq -r '.version // empty')
+          echo "value=${version}" >> $GITHUB_OUTPUT
+
+      - name: Log in to ghcr.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+      - name: Add tag with version to the image
+        env:
+          IMAGE_WITH_TAG: ${{ steps.build_image.outputs.image-with-tag }}
+          IMAGE_WITH_VERSION: "${{ steps.build_image.outputs.image }}:${{ steps.current-version.outputs.value }}"
+        run: podman tag ${IMAGE_WITH_TAG} ${IMAGE_WITH_VERSION}
+        if: inputs.publish-image
+
+      - name: Publish
+        id: push
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          tags: ${{ steps.current-version.outputs.value }} ${{ steps.build_image.outputs.tags }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+        if: inputs.publish-image
+
+      - name: Generate attestation for images
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE_REGISTRY }}/${{ steps.build_image.outputs.image }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+        if: inputs.publish-image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
 
     env:
       TAG: v${{ needs.meta.outputs.latest-version }}
-      COMMIT: ${{ github.event.pull_request.base.ref || github.event.before }} # either the PR base ref or previous commit in the branch
+      COMMIT: ${{ github.event.pull_request.base.sha || github.event.before }} # either the PR base ref or previous commit in the branch
       GH_REPOSITORY: ${{ github.repository }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,17 +139,23 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
   mark-previous-version:
-    needs: [build, meta]
+    needs: [build, meta, automerge]
     runs-on: ubuntu-latest
 
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.build.outputs.current-version != needs.meta.outputs.latest-version
+    if: |
+      (
+        (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        || (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]')
+      )
+      && needs.build.outputs.current-version != needs.meta.outputs.latest-version
+      && !cancelled()
 
     permissions:
       contents: write
 
     env:
       TAG: v${{ needs.meta.outputs.latest-version }}
-      COMMIT: ${{ github.event.before }}
+      COMMIT: ${{ github.event.pull_request.base.ref || github.event.before }} # either the PR base ref or previous commit in the branch
       GH_REPOSITORY: ${{ github.repository }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,12 @@ jobs:
   build:
     needs: meta
 
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+      packages: write
+
     uses: ./.github/workflows/build-image.yml
     with:
       image-name: ${{ needs.meta.outputs.implementation-name }}
@@ -112,6 +118,12 @@ jobs:
   # Executes only if 'automerge' is not skipped
   publish-on-automerge:
     needs: [meta, automerge]
+
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+      packages: write
 
     uses: ./.github/workflows/build-image.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Job is required to automatically publish an image for successfully merged dependabot's PR.
-  # PR is merged with GITHUB_TOKEN and it does not trigger the workflow run on 'push'
+  # PR is merged with GITHUB_TOKEN and it does not trigger the workflow run on 'push'.
+  # Executes only if 'automerge' is not skipped
   publish-on-automerge:
     needs: [meta, automerge]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
               --implementation ${IMPL_NAME} \
               --format json | jq -r '.version // empty')
           echo "value=${version}" >> $GITHUB_OUTPUT
+          echo "Latest version: $version"
 
   build:
     needs: meta

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,97 +46,11 @@ jobs:
   build:
     needs: meta
 
-    runs-on: ubuntu-latest
-
-    outputs:
-      current-version: ${{ steps.current-version.outputs.value }}
-
-    permissions:
-      id-token: write
-      contents: read
-      attestations: write
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Install bowtie
-        uses: bowtie-json-schema/bowtie@main
-
-      - name: Build
-        id: build_image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          context: '.'
-          containerfiles: |
-            Dockerfile
-          image: ${{ needs.meta.outputs.implementation-name }}
-          tags: ${{ github.sha }} ${{ github.ref == 'refs/heads/main' && 'latest' || '' }}
-          archs: amd64, arm64
-
-      - name: Set DOCKER_HOST so podman-built images are findable
-        run: |
-          systemctl --user enable --now podman.socket
-          sudo loginctl enable-linger $USER
-          podman --remote info
-          echo "DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')" >> $GITHUB_ENV
-
-      - name: Smoke Test
-        env:
-          IMAGE_WITH_TAG: ${{ steps.build_image.outputs.image-with-tag }}
-        run: |
-          bowtie smoke -i "localhost/${IMAGE_WITH_TAG}" --format json
-          bowtie smoke -i "localhost/${IMAGE_WITH_TAG}" --format markdown >> $GITHUB_STEP_SUMMARY
-
-      - name: Collect current version
-        id: current-version
-        env:
-          IMAGE_WITH_TAG: ${{ steps.build_image.outputs.image-with-tag }}
-        run: |
-          version=$(bowtie info \
-              --implementation "localhost/${IMAGE_WITH_TAG}" \
-              --format json | jq -r '.version // empty')
-          echo "value=${version}" >> $GITHUB_OUTPUT
-
-      - name: Print collected versions
-        env:
-          LATEST_VERSION: ${{ needs.meta.outputs.latest-version }}
-          CURRENT_VERSION: ${{ steps.current-version.outputs.value }}
-        run: echo "latest_version=${LATEST_VERSION}; current_version=${CURRENT_VERSION}"
-
-      - name: Log in to ghcr.io
-        uses: redhat-actions/podman-login@v1
-        with:
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-          registry: ${{ env.IMAGE_REGISTRY }}
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-      - name: Add tag with version to the image
-        env:
-          IMAGE_WITH_TAG: ${{ steps.build_image.outputs.image-with-tag }}
-          IMAGE_WITH_VERSION: "${{ steps.build_image.outputs.image }}:${{ steps.current-version.outputs.value }}"
-        run: podman tag ${IMAGE_WITH_TAG} ${IMAGE_WITH_VERSION}
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-      - name: Publish
-        id: push
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build_image.outputs.image }}
-          tags: ${{ steps.current-version.outputs.value }} ${{ steps.build_image.outputs.tags }}
-          registry: ${{ env.IMAGE_REGISTRY }}
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-      - name: Generate attestation for images
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ env.IMAGE_REGISTRY }}/${{ steps.build_image.outputs.image }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image-name: ${{ needs.meta.outputs.implementation-name }}
+      is-latest: ${{ github.ref == 'refs/heads/main' }}
+      publish-image: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
   mark-previous-version:
     needs: [build, meta, automerge]
@@ -192,3 +106,14 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Job is required to automatically publish an image for successfully merged dependabot's PR.
+  # PR is merged with GITHUB_TOKEN and it does not trigger the workflow run on 'push'
+  publish-on-automerge:
+    needs: [meta, automerge]
+
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image-name: ${{ needs.meta.outputs.implementation-name }}
+      is-latest: ${{ github.event.pull_request.base.ref == 'main' }}
+      publish-image: true


### PR DESCRIPTION
When PR is automatically merged the workflow on `push` to the main branch is not triggered because [GITHUB_TOKEN does not allow that](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow).
To overcome that we have added a new job that is triggered after a successful `automerge` job, and builds and publishes the image