### PR TITLE
Add test workflow to see the actual payload after run is completed

### DIFF
--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -1,0 +1,17 @@
+name: Build and publish test harness image after Dependabot PR
+
+on:
+  workflow_run: # zizmor: ignore[dangerous-triggers] we are aware that it is a dengerouse trigger but we need a way to build an image after Dependabot PR
+    types: [ completed ]
+    workflows: [ 'Rebuild Bowtie Image' ]
+
+permissions: {}
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print trigger event
+        env:
+          EVENT_PAYLOAD: ${{ toJson(github.event) }}
+        run: echo $EVENT_PAYLOAD


### PR DESCRIPTION
This PR adds a simple workflow with `workflow_run` trigger to see what the actual payload we receive when `build` workflow is completed.

Yes, the `workflow_run` is considered a dangerous trigger but we don't have many options to automate image publication after dependabot PR