### PR TITLE
Add workflow that is triggered after a successful dependabot PR

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,10 +3,6 @@ name: Build test harness image
 on:
   workflow_call:
     inputs:
-      image-name:
-        type: string
-        required: true
-        description: 'Name for the image to build'
       publish-image:
         type: boolean
         default: false
@@ -46,6 +42,12 @@ jobs:
       - name: Install bowtie
         uses: bowtie-json-schema/bowtie@main
 
+      - name: Compute implementation name
+        id: impl
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+        run: echo "name=$(echo ${GH_REPOSITORY} | awk -F '/' '{print $2}')" >> $GITHUB_OUTPUT
+
       - name: Build
         id: build_image
         uses: redhat-actions/buildah-build@v2
@@ -53,7 +55,7 @@ jobs:
           context: '.'
           containerfiles: |
             Dockerfile
-          image: ${{ inputs.image-name }}
+          image: ${{ steps.impl.outputs.name }}
           tags: ${{ github.sha }} ${{ inputs.is-latest && 'latest' || '' }}
           archs: amd64, arm64
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       latest-version: ${{ steps.version.outputs.value }}
-      implementation-name: ${{ steps.impl.outputs.name }}
     steps:
 
       - name: Install bowtie
@@ -55,7 +54,6 @@ jobs:
 
     uses: ./.github/workflows/build-image.yml
     with:
-      image-name: ${{ needs.meta.outputs.implementation-name }}
       is-latest: ${{ github.ref == 'refs/heads/main' }}
       publish-image: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
@@ -128,6 +126,5 @@ jobs:
 
     uses: ./.github/workflows/build-image.yml
     with:
-      image-name: ${{ needs.meta.outputs.implementation-name }}
       is-latest: ${{ github.event.pull_request.base.ref == 'main' }}
       publish-image: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,20 +111,3 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Job is required to automatically publish an image for successfully merged dependabot's PR.
-  # PR is merged with GITHUB_TOKEN and it does not trigger the workflow run on 'push'.
-  # Executes only if 'automerge' is not skipped
-  publish-on-automerge:
-    needs: [meta, automerge]
-
-    permissions:
-      id-token: write
-      contents: read
-      attestations: write
-      packages: write
-
-    uses: ./.github/workflows/build-image.yml
-    with:
-      is-latest: ${{ github.event.pull_request.base.ref == 'main' }}
-      publish-image: true

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -4,6 +4,8 @@ on:
   workflow_run: # zizmor: ignore[dangerous-triggers] we are aware that it is a dengerouse trigger but we need a way to build an image after Dependabot PR
     types: [ completed ]
     workflows: [ 'Rebuild Bowtie Image' ]
+    branches:
+      - 'dependabot/**'
 
 permissions: {}
 

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -7,11 +7,25 @@ on:
 
 permissions: {}
 
+concurrency:
+  # in this case if several dependabot PRs are merged only the latest one will build and publish the image
+  group: dependabot-${{ github.event.workflow_run.event }}-${{ github.event.workflow_run.triggering_actor.login }}
+  cancel-in-progress: true
+
 jobs:
   build-and-publish:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print trigger event
-        env:
-          EVENT_PAYLOAD: ${{ toJson(github.event) }}
-        run: echo $EVENT_PAYLOAD
+    if: |
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.triggering_actor.login == 'dependabot[bot]'
+
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+      packages: write
+
+    uses: ./.github/workflows/build-image.yml
+    with:
+      is-latest: true
+      publish-image: true


### PR DESCRIPTION
The idea of the workflow is the following:

- PR from dependabot passes all checks and gets merged into the main branch;
- The new workflow is triggered (according to [the documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run), we will be in the context of the main branch). Based on test runs - the PR commit is already there;
- Job checks out the branch, builds the image, and uploads it to the packages.

The `if` condition ensures that only successful PR from dependabot triggers the build.

The concurrency group ensures that only the latest PR from dependabot produces an image.