### PR TITLE
Fix mistake in reusable build workflow that did not log in to the registry when publish image

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -90,7 +90,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
           registry: ${{ env.IMAGE_REGISTRY }}
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: inputs.publish-image
 
       - name: Add tag with version to the image
         env:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.1.20"
-json-schema-validator = "0.5.1"
+json-schema-validator = "0.5.0"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
This PR also rolls back the version of the implementation to repeat the attempt for automated image creation