### PR TITLE
Hash-pin actions related to image creation

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build
         id: build_image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
           context: '.'
           containerfiles: |
@@ -93,7 +93,7 @@ jobs:
         run: echo "current_version=${CURRENT_VERSION}"
 
       - name: Log in to ghcr.io
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
           username: ${{ github.actor }}
           password: ${{ github.token }}
@@ -107,14 +107,14 @@ jobs:
 
       - name: Publish
         id: push
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
         with:
           image: ${{ steps.build_image.outputs.image }}
           tags: ${{ steps.current-version.outputs.value }} ${{ steps.build_image.outputs.tags }}
           registry: ${{ env.IMAGE_REGISTRY }}
 
       - name: Generate attestation for images
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ steps.build_image.outputs.image }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -114,7 +114,7 @@ jobs:
           registry: ${{ env.IMAGE_REGISTRY }}
 
       - name: Generate attestation for images
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
+        uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ steps.build_image.outputs.image }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -109,7 +109,7 @@ jobs:
         if: inputs.publish-image
 
       - name: Generate attestation for images
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
+        uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ steps.build_image.outputs.image }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Build
         id: build_image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # 2.13
         with:
           context: '.'
           containerfiles: |
@@ -85,7 +85,7 @@ jobs:
           echo "Collected version: $version"
 
       - name: Log in to ghcr.io
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
           username: ${{ github.actor }}
           password: ${{ github.token }}
@@ -101,7 +101,7 @@ jobs:
 
       - name: Publish
         id: push
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
         with:
           image: ${{ steps.build_image.outputs.image }}
           tags: ${{ steps.current-version.outputs.value }} ${{ steps.build_image.outputs.tags }}
@@ -109,7 +109,7 @@ jobs:
         if: inputs.publish-image
 
       - name: Generate attestation for images
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ steps.build_image.outputs.image }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
 
-    if: (!cancelled() && github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]')
+    if: (!cancelled() && github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'github_actions'))
 
     permissions:
       contents: write

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -2,7 +2,6 @@ rules:
   unpinned-uses:
     config:
       policies:
-        actions/attest-build-provenance: hash-pin
         actions/*: ref-pin
         redhat-actions/*: hash-pin
         "*": ref-pin

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -2,5 +2,7 @@ rules:
   unpinned-uses:
     config:
       policies:
+        actions/attest-build-provenance: hash-pin
         actions/*: ref-pin
+        redhat-actions/*: hash-pin
         "*": ref-pin

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -3,5 +3,4 @@ rules:
     config:
       policies:
         actions/*: ref-pin
-        redhat-actions/*: hash-pin
-        "*": ref-pin
+        bowtie-json-schema/bowtie: ref-pin


### PR DESCRIPTION
As discussed in the [thread](https://github.com/bowtie-json-schema/kotlin-kmp-json-schema-validator/pull/16#discussion_r2094147169), we pin actions (that used to build the harness image) to hash instead of ref