### PR TITLE
Change git tag suffix to something more unique

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
       contents: write
 
     env:
-      TAG: v${{ needs.meta.outputs.latest-version }}
+      VERSION: ${{ needs.meta.outputs.latest-version }}
       COMMIT: ${{ github.event.pull_request.base.sha || github.event.before }} # either the PR base ref or previous commit in the branch
       GH_REPOSITORY: ${{ github.repository }}
 
@@ -82,6 +82,7 @@ jobs:
       - name: Create a release for previous implementation version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: harness-release-${{ env.VERSION }}
         run: >
           gh api
           --method POST
@@ -90,8 +91,8 @@ jobs:
           /repos/${GH_REPOSITORY}/releases
           -f "tag_name=$TAG"
           -f "target_commitish=$COMMIT"
-          -f "name=$TAG"
-          -f "body=Automatic release for $TAG"
+          -f "name=$VERSION"
+          -f "body=Automatic release for $VERSION"
           -F "generate_release_notes=true"
 
 


### PR DESCRIPTION
The PR changes the automatically generated git tag to something more unique to avoid collisions with user-generated tags and test harnesses, which have a version starting with `v`.

The original discussion started [here](https://github.com/bowtie-json-schema/bowtie/pull/1916/files#r2020147132).