### PR TITLE
chore: Migrate to actions/attest as the old one simply wraps that action

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -37,6 +37,7 @@ jobs:
       contents: read
       attestations: write
       packages: write
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -114,7 +115,7 @@ jobs:
           registry: ${{ env.IMAGE_REGISTRY }}
 
       - name: Generate attestation for images
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ steps.build_image.outputs.image }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -33,6 +33,7 @@ jobs:
       contents: read
       attestations: write
       packages: write
+      artifact-metadata: write
 
     steps:
       - uses: actions/checkout@v6
@@ -109,7 +110,7 @@ jobs:
         if: inputs.publish-image
 
       - name: Generate attestation for images
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ steps.build_image.outputs.image }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
       contents: read
       attestations: write
       packages: write
+      artifact-metadata: write
 
     uses: ./.github/workflows/build-image.yml
     with:

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -26,6 +26,7 @@ jobs:
       contents: read
       attestations: write
       packages: write
+      artifact-metadata: write
 
     uses: ./.github/workflows/build-image.yml
     with:


### PR DESCRIPTION
Migrate to https://github.com/actions/attest because the old action now simply wraps the actions/attest.

Permissions are updated as recommended by the action's README